### PR TITLE
camera: Allow to use boottime as timestamp reference

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -37,6 +37,9 @@ license {
 
 cc_library_shared {
     name: "libcameraservice",
+    defaults: [
+        "needs_camera_boottime_defaults",
+    ],
 
     // Camera service source
 

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -351,6 +351,11 @@ status_t Camera3Device::initializeCommonLocked() {
         mTimestampOffset = getMonoToBoottimeOffset();
     }
 
+#ifdef TARGET_CAMERA_BOOTTIME_TIMESTAMP
+    // Always calculate the offset if requested
+    mTimestampOffset = getMonoToBoottimeOffset();
+#endif
+
     // Will the HAL be sending in early partial result metadata?
     camera_metadata_entry partialResultsCount =
             mDeviceInfo.find(ANDROID_REQUEST_PARTIAL_RESULT_COUNT);


### PR DESCRIPTION
* Some /mad/ HALs use boottime clock without reporting
  timestamp source as realtime
  -> Add a flag to force boottime offset calculation

[SebaUbuntu] Edit for Soong conditional

Change-Id: I56b623a1c2b58ca8a6287783d938fb665de201df